### PR TITLE
Fix casing of GitHub link

### DIFF
--- a/theme/base.html
+++ b/theme/base.html
@@ -84,7 +84,7 @@
                     <ul class="nav navbar-nav ml-auto">
                       <li class="nav-item">
                         <a href="{{ config.repo }}" class="nav-link" target="_blank">
-                          <i class="fa fa-github"></i> Github
+                          <i class="fa fa-github"></i> GitHub
                         </a>
                       </li>
                       {%- block search_button %}


### PR DESCRIPTION
This PR fixes the casing of the GitHub link in the top-right—it should have capital 'H'.