### PR TITLE
add curve.fi bug bounty

### DIFF
--- a/projects/curve.json
+++ b/projects/curve.json
@@ -2,6 +2,8 @@
   "project": "Curve",
   "project_url": "https://www.curve.fi/",
   "description": "Curve is an exchange liquidity pool on Ethereum (like Uniswap) designed for (1) extremely efficient stablecoin trading (2) low risk, supplemental fee income for liquidity providers, without an opportunity cost.",
+  "bounty": "https://www.curve.fi/bugbounty",
+  "bounty_max": "$50,000",
   "audits": [
     {
       "repos": [


### PR DESCRIPTION
Curve has recently added a new [bounty page](https://www.curve.fi/bugbounty) and thought that it'd be worth it to include it here.

