### PR TITLE
Update metamask.json to include new audit

### DIFF
--- a/projects/metamask.json
+++ b/projects/metamask.json
@@ -5,6 +5,18 @@
   "security_contact": "security@metamask.io",
   "audits": [
     {
+      "title": "Audit-Report MetaMask key-tree Interface",
+      "date": "02/23",
+      "auditor": "Cure53",
+      "url": "https://metamask.io/files/key-tree-audit-report.pdf",
+      "effort": "2 auditors",
+      "repos": [
+        {
+          "url": "https://github.com/MetaMask/key-tree"
+        }
+      ]
+    },
+    {
       "title": "MetaMask Plugin System + LavaMoat Audit ",
       "date": "03/20",
       "auditor": "Least Authority TFA GmbH",


### PR DESCRIPTION
This change adds the newest Cure53 audit of the metamask key-tree interface.